### PR TITLE
Fixed CRAN check error on R-Devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pscl
-Version: 1.5.4
-Date: 2019-12-09
+Version: 1.5.5
+Date: 2020-02-19
 Title: Political Science Computational Laboratory
 Author: Simon Jackman, with contributions from
         Alex Tahk, Achim Zeileis, Christina Maimone, Jim Fearon and Zoe Meers

--- a/R/dropRollCall.r
+++ b/R/dropRollCall.r
@@ -62,7 +62,7 @@ compareRollCallObjects <- function(old,new){
 
 
 dropRollCall <- function(object,dropList=NULL,debug=FALSE){
-  if(class(object)!="rollcall"){
+  if(!("rollcall" %in% class(object))){
     stop("dropRollCall only works for objects of class rollcall.")
   }
 
@@ -201,7 +201,7 @@ dropRollCall <- function(object,dropList=NULL,debug=FALSE){
     
     if(!is.null(tmpRollCall$legis.data) & sum(dropLegis)>0){
       tmpRollCall$legis.data <- tmpRollCall$legis.data[!dropLegis,]
-      if(class(object$legis.data)=="data.frame"){
+      if("data.frame" %in% class(object$legis.data)){
         class(tmpRollCall$legis.data) <- "data.frame"
         names(tmpRollCall$legis.data) <- names(object$legis.data)
       }
@@ -209,7 +209,7 @@ dropRollCall <- function(object,dropList=NULL,debug=FALSE){
 
     if(!is.null(tmpRollCall$vote.data) & sum(dropVotes)>0){
       tmpRollCall$vote.data <- tmpRollCall$vote.data[!dropVotes,]
-      if(class(object$vote.data)=="data.frame"){
+      if("data.frame" %in% class(object$vote.data)){
         class(tmpRollCall$vote.data) <- "data.frame"
         names(tmpRollCall$vote.data) <- names(object$vote.data)
       }

--- a/R/dropUnanimous.r
+++ b/R/dropUnanimous.r
@@ -4,14 +4,14 @@ dropUnanimous <- function(obj, lop=0){
 }
 
 dropUnanimous.rollcall <- function(obj,lop=0){
-  if(class(obj)!="rollcall")
+  if(!("rollcall" %in% class(obj)))
     stop("dropUnanimous.rollcall only defined for objects of class rollcall")
   dropRollCall(obj,
                dropList=list(lop=lop))
 }
 
 dropUnanimous.matrix <- function(obj,lop=0){
-  if(class(obj)!="matrix")
+  if(!("matrix" %in% class(obj)))
     stop("dropUnanimous.matrix only defined for objects of class matrix")
 
   if(lop>1 | lop<0 | is.na(lop) | !is.numeric(lop) | length(lop)!=1)

--- a/R/odTest.R
+++ b/R/odTest.R
@@ -2,7 +2,7 @@ odTest <- function(glmobj,
                    alpha=.05,
                    digits=max(3,getOption("digits")-3))
 {
-  if(class(glmobj)[1]!="negbin")
+  if(!("negbin" %in% class(glmobj)))
     stop("this function only works for objects of class negbin\n")
 
   if(alpha>1 | alpha<0)

--- a/R/plot.ideal.r
+++ b/R/plot.ideal.r
@@ -1,6 +1,6 @@
 ## ideal plotting functions
 plot.ideal <- function(x, conf.int=0.95, burnin=NULL, ...) {
-  if(class(x)!="ideal")
+  if(!("ideal" %in% class(x)))
     stop("plot.ideal only available for objects of class ideal")
   
   if(is.null(burnin))
@@ -31,7 +31,7 @@ plot1d <- function(x,
                    burnin=NULL,
                    showAllNames=FALSE,
                    ...){
-  if(class(x)!="ideal")
+  if(!("ideal" %in% class(x)))
     stop("plot.ideal only available for objects of class ideal")
   
   if(is.null(burnin))
@@ -140,7 +140,7 @@ plot2d <- function(x,
                    overlayCuttingPlanes=FALSE,
                    ...){
   
-  if(class(x)!="ideal")
+  if(!("ideal" %in% class(x)))
     stop("plot.ideal only available for objects of class ideal")
   
   if(is.null(burnin))
@@ -256,7 +256,7 @@ tracex <- function(object,
 
   warnOption <- options()$warn
   options(warn=-1)
-  if(class(object)!="ideal")
+  if(!("ideal" %in% class(object)))
     stop("object passed to function tracex must be of class ideal")
 
   if(is.null(d))

--- a/R/postProcess.r
+++ b/R/postProcess.r
@@ -2,7 +2,7 @@
 postProcess <- function(object,
                         constraints="normalize",
                         debug=FALSE){
-  if(class(object)!="ideal")
+  if(!("ideal" %in% class(object)))
     stop("postProcess only defined for objects of class ideal")
 
   ## not a list of normalizing constraint (i.e., usually "normalize=TRUE" with d=1)

--- a/R/predict.ideal.r
+++ b/R/predict.ideal.r
@@ -3,7 +3,7 @@ predict.ideal <- function(object,
                           cutoff=0.5,
                           burnin=NULL,
                           ...) {
-  if(class(object)!="ideal")
+  if(!("ideal" %in% class(object)))
     stop("predict.ideal only defined for objects of class ideal\n")
   
   if(is.null(object$beta)){
@@ -127,7 +127,7 @@ print.predict.ideal <- function(x,digits=2,...) {
 plot.predict.ideal <- function(x,
                                type=c("legis","votes"),
                                ...){
-  if(class(x)!="predict.ideal")
+  if(!("predict.ideal" %in% class(x)))
     stop("plot.predict.ideal only defined for objects of class predict.ideal")
 
   localType <- match.arg(type)

--- a/R/readKH.r
+++ b/R/readKH.r
@@ -174,7 +174,7 @@ strip.trailing.space <- function(x){
 
 ##   ## now actually try to read the data  
 ##   readResults <- try(readLines(file))
-##   if(class(readResults)=="try-error"){
+##   if("try-error" %in% class(readResults)){
 ##     cat(paste("readKH error: could not read from",file,"\n",
 ##               "execution terminating\n"))
 ##     data <- NULL

--- a/R/restrict.ideal.r
+++ b/R/restrict.ideal.r
@@ -3,7 +3,7 @@ constrain.legis <- function(obj,
                             dropList=list(codes="notInLegis",lop=0),
                             x, d=1){
   options(warn=-1)
-  if(class(obj)!="rollcall")
+  if(!("rollcall" %in% class(obj)))
     stop("object must be of class rollcall")
   
   ## check dimensions of x list items
@@ -67,8 +67,8 @@ constrain.items <- function(obj,
                             dropList=list(codes="notInLegis",lop=0),
                             x, d=1){
   options(warn=-1)
-  if(class(obj)!="rollcall")
-    stop("object must be of class rollcall")
+  if(!("rollcall" %in% class(obj)))
+     stop("object must be of class rollcall")
   options(warn=0)
 
   rc <- dropRollCall(obj,dropList)

--- a/R/rollcall.r
+++ b/R/rollcall.r
@@ -182,7 +182,7 @@ print.rollcall <- function(x,print.votes=FALSE, ...){
 
 ## check Votes
 checkVotes <- function(object,codes=object$codes){
-  if(class(object)[1]=="rollcall"){
+  if("rollcall" %in% class(object)){
     mat <- object$votes
   } else {
     if("matrix" %in% class(object)) {
@@ -359,7 +359,7 @@ lopLook <- function(margins,cutOff){
 vectorRepresentation <- function(object,
                                  dropList=list(codes=c("missing",
                                                  "notInLegis"))){
-  if(class(object)!="rollcall")
+  if(!("rollcall" %in% class(object)))
     stop("vectorRepresentation only defined for objects of class rollcall")
   if(is.null(object$codes))
     stop("no rollcall codes")
@@ -436,7 +436,7 @@ summary.rollcall <- function(object,
                              verbose=FALSE,
                              debug=FALSE,
                              ...){
-  if(class(object)!="rollcall")
+  if(!("rollcall" %in% class(object)))
     stop("summary.rollcall only operates on objects of class rollcall")
 
   mc <- match.call()   ## how were we called
@@ -552,7 +552,7 @@ printDropTab <- function(x){
 }
 
 print.summary.rollcall <- function(x, digits=1, ...){
-  if(class(x)!="summary.rollcall")
+  if(!("summary.rollcall" %in% class(x)))
     stop("print.summary.rollcall only defined for objects of class summary.rollcall")
     
   rcObj <- x$call$object

--- a/R/summary.ideal.r
+++ b/R/summary.ideal.r
@@ -19,7 +19,7 @@ printHeaderIdeal <- function(x){
 
 ## summary and print functions
 print.ideal <- function(x, ...) {
-  if(class(x) != "ideal")
+  if(!("ideal" %in% class(x)))
     stop("object passed to print.ideal is not of class ideal\n")
 
   cat("Markov chain Monte Carlo Analysis of Roll Call Data\n")
@@ -47,7 +47,7 @@ summary.ideal <- function(object,
                           include.beta=FALSE,
                           ...){
 
-  if(class(object)!="ideal")
+  if(!("ideal" %in% class(object)))
     stop("summary.ideal only defined for objects of class ideal")
 
   if(!is.null(object$call$file)){

--- a/R/toMCMC.r
+++ b/R/toMCMC.r
@@ -1,7 +1,7 @@
 ## convert ideal object to MCMC object
 
 idealToMCMC <- function(object, burnin=NULL){
-  if(class(object)!="ideal")
+  if(!("ideal" %in% class(object)))
     stop("idealToMCMC only defined for objects of class ideal")
   
   if(is.null(burnin))


### PR DESCRIPTION
The pscl package was failing R CMD check on R-devel (particularly on linux systems) because of a new policy for classes and as such is about to be archived.  Apparently, R will now assign some built-in classes to objects independent of those assigned by the function/user.  As such, class(x) generally returns a vector of at least length 2, so any (in)equality, like `class(x) == "x"` triggers an error.  I changed all `if(class(x)=="x")` statements to `if("x %in% class(x))` and all `if(class(x)!="x")` to `if(!("x" %in% class(x)))`.  After doing so, the package checked clean on R-devel (Debian 9.5).  