### PR TITLE
Bug fixes for `pscl`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pscl
-Version: 1.5.6
-Date: 2020-03-08
+Version: 1.5.7
+Date: 2023-02-20
 Title: Political Science Computational Laboratory
 Author: Simon Jackman, with contributions from
         Alex Tahk, Achim Zeileis, Christina Maimone, Jim Fearon and Zoe Meers

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.5.7   * Add drop = FALSE to some matrices in the zeroinfl and hurdle functions.
+        * Specify that the optim convergence must equal 0 (which means the model converged) in the zeroinfl function.
+        
 1.5.5   * changed "class(obj) == X" to "inherits(obj, X)" or is.data.frame
           for compatibility with R 4.0
 

--- a/R/hurdle.R
+++ b/R/hurdle.R
@@ -470,7 +470,7 @@ vcov.hurdle <- function(object, model = c("full", "count", "zero"), ...) {
 
   cf <- object$coefficients[[model]]
   wi <- seq(along = object$coefficients$count)
-  rval <- if(model == "count") rval[wi, wi] else rval[-wi, -wi]
+  rval <- if(model == "count") rval[wi, wi, drop = FALSE] else rval[-wi, -wi, drop = FALSE]
   colnames(rval) <- rownames(rval) <- names(cf)
   return(rval)
 }

--- a/R/zeroinfl.R
+++ b/R/zeroinfl.R
@@ -2,7 +2,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
                      dist = c("poisson", "negbin", "geometric"),
                      link = c("logit", "probit", "cloglog", "cauchit", "log"),
 		     control = zeroinfl.control(...),
-		     model = TRUE, y = TRUE, x = FALSE, ...)
+		     model = TRUE, y = TRUE, x = FALSE)
 {
   ## set up likelihood
   ziPoisson <- function(parms, trunc.start=FALSE) {
@@ -512,7 +512,7 @@ vcov.zeroinfl <- function(object, model = c("full", "count", "zero"), ...) {
 
   cf <- object$coefficients[[model]]
   wi <- seq(along = object$coefficients$count)
-  rval <- if(model == "count") rval[wi, wi] else rval[-wi, -wi]
+  rval <- if(model == "count") rval[wi, wi, drop = FALSE] else rval[-wi, -wi, drop = FALSE]
   colnames(rval) <- rownames(rval) <- names(cf)
   return(rval)
 }

--- a/R/zeroinfl.R
+++ b/R/zeroinfl.R
@@ -2,7 +2,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
                      dist = c("poisson", "negbin", "geometric"),
                      link = c("logit", "probit", "cloglog", "cauchit", "log"),
 		     control = zeroinfl.control(...),
-		     model = TRUE, y = TRUE, x = FALSE,...)
+		     model = TRUE, y = TRUE, x = FALSE, ...)
 {
   ## set up likelihood
   ziPoisson <- function(parms, trunc.start=FALSE) {

--- a/R/zeroinfl.R
+++ b/R/zeroinfl.R
@@ -1,8 +1,8 @@
 zeroinfl <- function(formula, data, subset, na.action, weights, offset,
                      dist = c("poisson", "negbin", "geometric"),
                      link = c("logit", "probit", "cloglog", "cauchit", "log"),
-		     control = zeroinfl.control(...),
-		     model = TRUE, y = TRUE, x = FALSE, ...)
+                     control = zeroinfl.control(...),
+                     model = TRUE, y = TRUE, x = FALSE, ...)
 {
   ## set up likelihood
   ziPoisson <- function(parms, trunc.start=FALSE) {
@@ -39,7 +39,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     ## log-likelihood for y = 0 and y >= 1
     loglik0 <- log( phi + exp( log(1-phi) + suppressWarnings(dnbinom(0, size = theta, mu = mu, log = TRUE)) ) )
     loglik1 <- log(1-phi) + suppressWarnings(dnbinom(Y, size = theta, mu = mu, log = TRUE))
-
+    
     ## collect and return
     if (trunc.start)
       sum(weights[Y1] * loglik1[Y1]) - sum(weights[Y1] * log(1 - exp(loglik0[Y1])))
@@ -49,38 +49,38 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   
   ziGeom <- function(parms, trunc.start=FALSE)
     ziNegBin(c(parms, 0), trunc.start)
-
+  
   countGradPoisson <- function(parms) {
     eta <- as.vector(X %*% parms[1:kx] + offsetx)[Y1]
     mu <- exp(eta)
     colSums(((Y[Y1] - mu) - exp(ppois(0, lambda = mu, log.p = TRUE) -
-      ppois(0, lambda = mu, lower.tail = FALSE, log.p = TRUE) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
+                                  ppois(0, lambda = mu, lower.tail = FALSE, log.p = TRUE) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
   }
   
   countGradGeom <- function(parms) {
     eta <- as.vector(X %*% parms[1:kx] + offsetx)[Y1]
     mu <- exp(eta)      
     colSums(((Y[Y1] - mu * (Y[Y1] + 1)/(mu + 1)) -
-      exp(pnbinom(0, mu = mu, size = 1, log.p = TRUE) -
-        pnbinom(0, mu = mu, size = 1, lower.tail = FALSE, log.p = TRUE) -
-	log(mu + 1) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
+               exp(pnbinom(0, mu = mu, size = 1, log.p = TRUE) -
+                     pnbinom(0, mu = mu, size = 1, lower.tail = FALSE, log.p = TRUE) -
+                     log(mu + 1) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
   }
-
+  
   countGradNegBin <- function(parms) {
     eta <- as.vector(X %*% parms[1:kx] + offsetx)[Y1]
     mu <- exp(eta)      
     theta <- exp(parms[kx+1])
     logratio <- pnbinom(0, mu = mu, size = theta, log.p = TRUE) -
-        pnbinom(0, mu = mu, size = theta, lower.tail = FALSE, log.p = TRUE)
+      pnbinom(0, mu = mu, size = theta, lower.tail = FALSE, log.p = TRUE)
     rval <- colSums(((Y[Y1] - mu * (Y[Y1] + theta)/(mu + theta)) -
-      exp(logratio + log(theta) - log(mu + theta) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
+                       exp(logratio + log(theta) - log(mu + theta) + eta)) * weights[Y1] * X[Y1, , drop = FALSE])
     rval2 <- sum((digamma(Y[Y1] + theta) - digamma(theta) +    
-      log(theta) - log(mu + theta) + 1 - (Y[Y1] + theta)/(mu + theta) +
-      exp(logratio) * (log(theta) - log(mu + theta) + 1 - theta/(mu + theta))) * weights[Y1]) * theta
+                    log(theta) - log(mu + theta) + 1 - (Y[Y1] + theta)/(mu + theta) +
+                    exp(logratio) * (log(theta) - log(mu + theta) + 1 - theta/(mu + theta))) * weights[Y1]) * theta
     c(rval, rval2)
   }  
-
-    
+  
+  
   gradPoisson <- function(parms) {
     ## count mean
     eta <- as.vector(X %*% parms[1:kx] + offsetx)
@@ -88,16 +88,16 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     ## binary mean
     etaz <- as.vector(Z %*% parms[(kx+1):(kx+kz)] + offsetz)
     muz <- linkinv(etaz)
-  
+    
     ## densities at 0
     clogdens0 <- -mu
     dens0 <- muz * (1 - as.numeric(Y1)) + exp(log(1 - muz) + clogdens0)
-
+    
     ## working residuals  
     wres_count <- ifelse(Y1, Y - mu, -exp(-log(dens0) + log(1 - muz) + clogdens0 + log(mu)))
     wres_zero <- ifelse(Y1, -1/(1-muz) * linkobj$mu.eta(etaz),
-      (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
-      
+                        (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
+    
     colSums(cbind(wres_count * weights * X, wres_zero * weights * Z))
   }
   
@@ -108,20 +108,20 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     ## binary mean
     etaz <- as.vector(Z %*% parms[(kx+1):(kx+kz)] + offsetz)
     muz <- linkinv(etaz)
-
+    
     ## densities at 0
     clogdens0 <- dnbinom(0, size = 1, mu = mu, log = TRUE)
     dens0 <- muz * (1 - as.numeric(Y1)) + exp(log(1 - muz) + clogdens0)
-
+    
     ## working residuals  
     wres_count <- ifelse(Y1, Y - mu * (Y + 1)/(mu + 1), -exp(-log(dens0) +
-      log(1 - muz) + clogdens0 - log(mu + 1) + log(mu)))
+                                                               log(1 - muz) + clogdens0 - log(mu + 1) + log(mu)))
     wres_zero <- ifelse(Y1, -1/(1-muz) * linkobj$mu.eta(etaz),
-      (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
-      
+                        (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
+    
     colSums(cbind(wres_count * weights * X, wres_zero * weights * Z))
   }
-
+  
   gradNegBin <- function(parms) {
     ## count mean
     eta <- as.vector(X %*% parms[1:kx] + offsetx)
@@ -131,43 +131,43 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     muz <- linkinv(etaz)
     ## negbin size
     theta <- exp(parms[(kx+kz)+1])
-
+    
     ## densities at 0
     clogdens0 <- dnbinom(0, size = theta, mu = mu, log = TRUE)
     dens0 <- muz * (1 - as.numeric(Y1)) + exp(log(1 - muz) + clogdens0)
-
+    
     ## working residuals  
     wres_count <- ifelse(Y1, Y - mu * (Y + theta)/(mu + theta), -exp(-log(dens0) +
-      log(1 - muz) + clogdens0 + log(theta) - log(mu + theta) + log(mu)))
+                                                                       log(1 - muz) + clogdens0 + log(theta) - log(mu + theta) + log(mu)))
     wres_zero <- ifelse(Y1, -1/(1-muz) * linkobj$mu.eta(etaz),
-      (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
+                        (linkobj$mu.eta(etaz) - exp(clogdens0) * linkobj$mu.eta(etaz))/dens0)
     wres_theta <- theta * ifelse(Y1, digamma(Y + theta) - digamma(theta) +
-      log(theta) - log(mu + theta) + 1 - (Y + theta)/(mu + theta),
-      exp(-log(dens0) + log(1 - muz) + clogdens0) *
-      (log(theta) - log(mu + theta) + 1 - theta/(mu + theta)))
-
+                                   log(theta) - log(mu + theta) + 1 - (Y + theta)/(mu + theta),
+                                 exp(-log(dens0) + log(1 - muz) + clogdens0) *
+                                   (log(theta) - log(mu + theta) + 1 - theta/(mu + theta)))
+    
     colSums(cbind(wres_count * weights * X, wres_zero * weights * Z, wres_theta))
   }
-    
+  
   dist <- match.arg(dist)
   loglikfun <- switch(dist,
                       "poisson" = ziPoisson,
-		      "geometric" = ziGeom,
-		      "negbin" = ziNegBin)
+                      "geometric" = ziGeom,
+                      "negbin" = ziNegBin)
   gradfun <- switch(dist,
-                      "poisson" = gradPoisson,
-		      "geometric" = gradGeom,
-		      "negbin" = gradNegBin)
-
+                    "poisson" = gradPoisson,
+                    "geometric" = gradGeom,
+                    "negbin" = gradNegBin)
+  
   ## binary link processing
   linkstr <- match.arg(link)
   linkobj <- make.link(linkstr)
   linkinv <- linkobj$linkinv
-
+  
   if(control$trace) cat("Zero-inflated Count Model\n",
-    paste("count model:", dist, "with log link\n"),
-    paste("zero-inflation model: binomial with", linkstr, "link\n"), sep = "")
-	     
+                        paste("count model:", dist, "with log link\n"),
+                        paste("zero-inflation model: binomial with", linkstr, "link\n"), sep = "")
+  
   
   ## call and formula
   cl <- match.call()
@@ -196,7 +196,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   if(inherits(try(terms(ffz), silent = TRUE), "try-error")) {
     ffz <- eval(parse(text = sprintf( paste("%s -", deparse(ffc[[2]])), deparse(ffz) )))
   }
-
+  
   ## call model.frame()
   mf[[1]] <- as.name("model.frame")
   mf <- eval(mf, parent.frame())
@@ -209,8 +209,8 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   mtZ <- terms(update(mtZ, ~ .), data = data)
   Z <- model.matrix(mtZ, mf)
   Y <- model.response(mf, "numeric")
-
-
+  
+  
   ## sanity checks
   if(length(Y) < 1) stop("empty model")
   if(all(Y > 0)) stop("invalid dependent variable, minimum count is not zero")  
@@ -225,14 +225,14 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     names(dimnames(tab)) <- NULL
     print(tab)
   }
-      
+  
   ## convenience variables
   n <- length(Y)
   kx <- NCOL(X)
   kz <- NCOL(Z)
   Y0 <- Y <= 0
   Y1 <- Y > 0
-
+  
   ## weights and offset
   weights <- model.weights(mf)
   if(is.null(weights)) weights <- 1
@@ -248,7 +248,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   if(is.null(offsetz)) offsetz <- 0
   if(length(offsetz) == 1) offsetz <- rep.int(offsetz, n)
   offsetz <- as.vector(offsetz)
-
+  
   ## starting values
   start <- control$start
   if(!is.null(start)) {
@@ -279,7 +279,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     }
     if(!valid) start <- NULL
   }
-
+  
   method <- control$method
   hessian <- control$hessian
   ocontrol <- control
@@ -288,51 +288,51 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   if(is.null(start)) {
     if(control$trace) cat("generating starting values...")
     model_zero <- glm.fit(Z, as.integer(Y0), weights = weights, family = binomial(link = linkstr), offset = offsetz)
-
+    
     countloglikfun <- function(parms)
-        loglikfun(c(parms[1:kx], rep(0, kz), parms[-(1:kx)]),
-                  trunc.start = TRUE)
+      loglikfun(c(parms[1:kx], rep(0, kz), parms[-(1:kx)]),
+                trunc.start = TRUE)
     countgradfun <- switch(dist,
-                      "poisson" = countGradPoisson,
-		      "geometric" = countGradGeom,
-		      "negbin" = countGradNegBin)
-
+                           "poisson" = countGradPoisson,
+                           "geometric" = countGradGeom,
+                           "negbin" = countGradNegBin)
+    
     lmstart <- lm.wfit(X[Y1,,drop=FALSE],
                        log(Y[Y1]) - offsetx[Y1],
                        weights[Y1])$coefficients
     lmstart <- ifelse(is.na(lmstart), 0, lmstart)
-
+    
     fit <- tryCatch(optim(fn = countloglikfun, gr = countgradfun,
-        par = c(lmstart, if(dist == "negbin") 0 else NULL),
-        method = method, hessian = FALSE, control = control),
-        error = function(e) list(convergence=1))
-
+                          par = c(lmstart, if(dist == "negbin") 0 else NULL),
+                          method = method, hessian = FALSE, control = control),
+                    error = function(e) list(convergence=1))
+    
     if(fit$convergence == 0) {
-        model_count <- glm.fit(X, Y, family = poisson(), weights = weights, offset = offsetx)
-        start <- list(count = model_count$coefficients, zero = model_zero$coefficients)
-        if(dist == "negbin") start$theta <- 1
+      model_count <- glm.fit(X, Y, family = poisson(), weights = weights, offset = offsetx)
+      start <- list(count = model_count$coefficients, zero = model_zero$coefficients)
+      if(dist == "negbin") start$theta <- 1
     } else {
-        start <- list(count = fit$par[1:kx], zero = model_zero$coefficients)
-        if (length(fit$par) > kx)
-            start$theta <- exp(fit$par[-(1:kx)])
+      start <- list(count = fit$par[1:kx], zero = model_zero$coefficients)
+      if (length(fit$par) > kx)
+        start$theta <- exp(fit$par[-(1:kx)])
     }
-
+    
     ## EM estimation of starting values
-    if(ocontrol$EM & dist == "poisson" & fit$convergence == 0) {
+    if(ocontrol$EM & dist == "poisson" & fit$converge == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dpois(0, mui))
       probi[Y1] <- 0
-
+      
       ll_new <- loglikfun(c(start$count, start$zero))
       ll_old <- 2 * ll_new
-
+      
       while(abs((ll_old - ll_new)/ll_old) > control$reltol) {
         ll_old <- ll_new
         model_count <- glm.fit(X, Y, weights = weights * (1-probi), offset = offsetx,
-	  family = poisson(), start = start$count)
+                               family = poisson(), start = start$count)
         model_zero <- suppressWarnings(glm.fit(Z, probi, weights = weights, offset = offsetz,
-	  family = binomial(link = linkstr), start = start$zero))
+                                               family = binomial(link = linkstr), start = start$zero))
         mui <- model_count$fitted
         probi <- model_zero$fitted
         probi <- probi/(probi + (1-probi) * dpois(0, mui))
@@ -341,26 +341,26 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
         ll_new <- loglikfun(c(start$count, start$zero))
       }
     }
-
-    if(ocontrol$EM & dist == "geometric" & fit$convergence == 0) {
+    
+    if(ocontrol$EM & dist == "geometric" & fit$converge == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dnbinom(0, size = 1, mu = mui))
       probi[Y1] <- 0
-
+      
       ll_new <- loglikfun(c(start$count, start$zero))
-      ll_old <- 2 * ll_new
+      ll_old <- 2 * ll_new      
       ##if(!require("MASS")) {
       ##  ll_old <- ll_new
       ##	warning("EM estimation of starting values not available")
       ## }
-
+      
       while(abs((ll_old - ll_new)/ll_old) > control$reltol) {
         ll_old <- ll_new
         model_count <- suppressWarnings(glm.fit(X, Y, weights = weights * (1-probi),
-	  offset = offsetx, family = MASS::negative.binomial(1), start = start$count))
+                                                offset = offsetx, family = MASS::negative.binomial(1), start = start$count))
         model_zero <- suppressWarnings(glm.fit(Z, probi, weights = weights,
-	  offset = offsetz, family = binomial(link = linkstr), start = start$zero))
+                                               offset = offsetz, family = binomial(link = linkstr), start = start$zero))
         start <- list(count = model_count$coefficients, zero = model_zero$coefficients)
         mui <- model_count$fitted
         probi <- model_zero$fitted
@@ -369,29 +369,29 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
         ll_new <- loglikfun(c(start$count, start$zero))
       }
     }
-
-    if(ocontrol$EM & dist == "negbin" & fit$convergence == 0) {
+    
+    if(ocontrol$EM & dist == "negbin" & fit$converge == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dnbinom(0, size = start$theta, mu = mui))
       probi[Y1] <- 0
-
-      ll_new <- loglikfun(c(start$count, start$zero, log(start$theta)))
-      ll_old <- 2 * ll_new
+      
+      ll_new <- loglikfun(c(start$count, start$zero, log(start$theta)))      
+      ll_old <- 2 * ll_new      
       ## if(!require("MASS")) {
       ##   ll_old <- ll_new
       ##   warning("EM estimation of starting values not available")
       ## }
-
+      
       ## offset handling in glm.nb is sub-optimal, hence...
       offset <- offsetx
-
+      
       while(abs((ll_old - ll_new)/ll_old) > control$reltol) {
         ll_old <- ll_new
         model_count <- suppressWarnings(glm.nb(Y ~ 0 + X + offset(offset), weights = weights * (1-probi),
-	  start = start$count, init.theta = start$theta))
+                                               start = start$count, init.theta = start$theta))
         model_zero <- suppressWarnings(glm.fit(Z, probi, weights = weights, offset = offsetz,
-	  family = binomial(link = linkstr), start = start$zero))
+                                               family = binomial(link = linkstr), start = start$zero))
         start <- list(count = model_count$coefficients, zero = model_zero$coefficients, theta = model_count$theta)
         mui <- model_count$fitted
         probi <- model_zero$fitted
@@ -400,33 +400,32 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
         ll_new <- loglikfun(c(start$count, start$zero, log(start$theta)))
       }
     }
-
+    
     if(control$trace) cat("done\n")
   }
   
-
-
+  
   ## ML estimation
   if(control$trace) cat("calling optim() for ML estimation:\n")
-
+  
   fit <- optim(fn = loglikfun, gr = gradfun,
-    par = c(start$count, start$zero, if(dist == "negbin") log(start$theta) else NULL),
-    method = method, hessian = hessian, control = control)
+               par = c(start$count, start$zero, if(dist == "negbin") log(start$theta) else NULL),
+               method = method, hessian = hessian, control = control)
   if(fit$convergence > 0) warning("optimization failed to converge")
-
+  
   ## coefficients and covariances
   coefc <- fit$par[1:kx]
   names(coefc) <- names(start$count) <- colnames(X)
   coefz <- fit$par[(kx+1):(kx+kz)]
   names(coefz) <- names(start$zero) <- colnames(Z)
-
+  
   vc <- tryCatch(-solve(as.matrix(fit$hessian)),
                  error=function(e) {
-                     warning(e$message, call=FALSE)
-                     k <- nrow(as.matrix(fit$hessian))
-                     return(matrix(NA, k, k))
+                   warning(e$message, call=FALSE)
+                   k <- nrow(as.matrix(fit$hessian))
+                   return(matrix(NA, k, k))
                  })
-
+  
   if(dist == "negbin") {
     np <- kx + kz + 1
     theta <- as.vector(exp(fit$par[np]))
@@ -438,47 +437,47 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
   }
   colnames(vc) <- rownames(vc) <- c(paste("count", colnames(X), sep = "_"),
                                     paste("zero",  colnames(Z), sep = "_"))
-
+  
   ## fitted and residuals
   mu <- exp(X %*% coefc + offsetx)[,1]
   phi <- linkinv(Z %*% coefz + offsetz)[,1]
   Yhat <- (1-phi) * mu
   res <- sqrt(weights) * (Y - Yhat)
-
+  
   ## effective observations
   nobs <- sum(weights > 0) ## = n - sum(weights == 0)
-
+  
   rval <- list(coefficients = list(count = coefc, zero = coefz),
-    residuals = res,
-    fitted.values = Yhat,
-    optim = fit,
-    method = method,
-    control = ocontrol,
-    start = start,
-    weights = if(identical(as.vector(weights), rep.int(1L, n))) NULL else weights,
-    offset = list(count = if(identical(offsetx, rep.int(0, n))) NULL else offsetx,
-      zero = if(identical(offsetz, rep.int(0, n))) NULL else offsetz),
-    n = nobs,
-    df.null = nobs - 2,
-    df.residual = nobs - (kx + kz + (dist == "negbin")),
-    terms = list(count = mtX, zero = mtZ, full = mt),
-    theta = theta,
-    SE.logtheta = SE.logtheta,
-    loglik = fit$value,
-    vcov = vc,
-    dist = dist,
-    link = linkstr,
-    linkinv = linkinv,
-    converged = fit$convergence < 1,
-    call = cl,
-    formula = ff,
-    levels = .getXlevels(mt, mf),
-    contrasts = list(count = attr(X, "contrasts"), zero = attr(Z, "contrasts"))
+               residuals = res,
+               fitted.values = Yhat,
+               optim = fit,
+               method = method,
+               control = ocontrol,
+               start = start,
+               weights = if(identical(as.vector(weights), rep.int(1L, n))) NULL else weights,
+               offset = list(count = if(identical(offsetx, rep.int(0, n))) NULL else offsetx,
+                             zero = if(identical(offsetz, rep.int(0, n))) NULL else offsetz),
+               n = nobs,
+               df.null = nobs - 2,
+               df.residual = nobs - (kx + kz + (dist == "negbin")),
+               terms = list(count = mtX, zero = mtZ, full = mt),
+               theta = theta,
+               SE.logtheta = SE.logtheta,
+               loglik = fit$value,
+               vcov = vc,
+               dist = dist,
+               link = linkstr,
+               linkinv = linkinv,
+               converged = fit$convergence < 1,
+               call = cl,
+               formula = ff,
+               levels = .getXlevels(mt, mf),
+               contrasts = list(count = attr(X, "contrasts"), zero = attr(Z, "contrasts"))
   )
   if(model) rval$model <- mf
   if(y) rval$y <- Y
   if(x) rval$x <- list(count = X, zero = Z)
-
+  
   class(rval) <- "zeroinfl"
   return(rval)
 }
@@ -499,10 +498,10 @@ coef.zeroinfl <- function(object, model = c("full", "count", "zero"), ...) {
   rval <- object$coefficients
   rval <- switch(model,
                  "full" = structure(c(rval$count, rval$zero),
-		   .Names = c(paste("count", names(rval$count), sep = "_"),
-                   paste("zero", names(rval$zero), sep = "_"))),
-		 "count" = rval$count,
-		 "zero" = rval$zero)
+                                    .Names = c(paste("count", names(rval$count), sep = "_"),
+                                               paste("zero", names(rval$zero), sep = "_"))),
+                 "count" = rval$count,
+                 "zero" = rval$zero)
   rval
 }
 
@@ -510,10 +509,10 @@ vcov.zeroinfl <- function(object, model = c("full", "count", "zero"), ...) {
   model <- match.arg(model)
   rval <- object$vcov
   if(model == "full") return(rval)
-
+  
   cf <- object$coefficients[[model]]
   wi <- seq(along = object$coefficients$count)
-  rval <- if(model == "count") rval[wi, wi, drop = FALSE] else rval[-wi, -wi, drop = FALSE]
+  rval <- if(model == "count") rval[wi, wi] else rval[-wi, -wi]
   colnames(rval) <- rownames(rval) <- names(cf)
   return(rval)
 }
@@ -524,7 +523,7 @@ logLik.zeroinfl <- function(object, ...) {
 
 print.zeroinfl <- function(x, digits = max(3, getOption("digits") - 3), ...)
 {
-
+  
   cat("\nCall:", deparse(x$call, width.cutoff = floor(getOption("width") * 0.85)), "", sep = "\n")
   
   if(!x$converged) {
@@ -533,7 +532,7 @@ print.zeroinfl <- function(x, digits = max(3, getOption("digits") - 3), ...)
     cat(paste("Count model coefficients (", x$dist, " with log link):\n", sep = ""))
     print.default(format(x$coefficients$count, digits = digits), print.gap = 2, quote = FALSE)
     if(x$dist == "negbin") cat(paste("Theta =", round(x$theta, digits), "\n"))
-  
+    
     cat(paste("\nZero-inflation model coefficients (binomial with ", x$link, " link):\n", sep = ""))
     print.default(format(x$coefficients$zero, digits = digits), print.gap = 2, quote = FALSE)
     cat("\n")
@@ -567,7 +566,7 @@ summary.zeroinfl <- function(object,...)
   ## delete some slots
   object$fitted.values <- object$terms <- object$model <- object$y <-
     object$x <- object$levels <- object$contrasts <- object$start <- NULL
-
+  
   ## return
   class(object) <- "summary.zeroinfl"
   object
@@ -575,26 +574,26 @@ summary.zeroinfl <- function(object,...)
 
 print.summary.zeroinfl <- function(x, digits = max(3, getOption("digits") - 3), ...)
 {
-
+  
   cat("\nCall:", deparse(x$call, width.cutoff = floor(getOption("width") * 0.85)), "", sep = "\n")
   
   if(!x$converged) {
     cat("model did not converge\n")
   } else {
-
+    
     cat("Pearson residuals:\n")
     print(structure(quantile(x$residuals),
-      names = c("Min", "1Q", "Median", "3Q", "Max")), digits = digits, ...)  
-
+                    names = c("Min", "1Q", "Median", "3Q", "Max")), digits = digits, ...)  
+    
     cat(paste("\nCount model coefficients (", x$dist, " with log link):\n", sep = ""))
     printCoefmat(x$coefficients$count, digits = digits, signif.legend = FALSE)
-  
+    
     cat(paste("\nZero-inflation model coefficients (binomial with ", x$link, " link):\n", sep = ""))
     printCoefmat(x$coefficients$zero, digits = digits, signif.legend = FALSE)
     
     if(getOption("show.signif.stars") & any(rbind(x$coefficients$count, x$coefficients$zero)[,4] < 0.1, na.rm=TRUE))
       cat("---\nSignif. codes: ", "0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1", "\n")
-
+    
     if(x$dist == "negbin") cat(paste("\nTheta =", round(x$theta, digits), "\n")) else cat("\n")
     cat(paste("Number of iterations in", x$method, "optimization:", tail(na.omit(x$optim$count), 1), "\n"))
     cat("Log-likelihood:", formatC(x$loglik, digits = digits), "on", x$n - x$df.residual, "Df\n")
@@ -604,75 +603,75 @@ print.summary.zeroinfl <- function(x, digits = max(3, getOption("digits") - 3), 
 }
 
 predict.zeroinfl <- function(object, newdata, type = c("response", "prob", "count", "zero"),
-  na.action = na.pass, at = NULL, ...)
+                             na.action = na.pass, at = NULL, ...)
 {
-    type <- match.arg(type)
-
-    ## if no new data supplied
-    if(missing(newdata)) {
-      rval <- object$fitted.values
-      if(type != "response") {
-        if(!is.null(object$x)) {
-	  X <- object$x$count
-	  Z <- object$x$zero
-	} else if(!is.null(object$model)) {
-          X <- model.matrix(object$terms$count, object$model, contrasts = object$contrasts$count)
-          Z <- model.matrix(object$terms$zero,  object$model, contrasts = object$contrasts$zero)	
-	} else {
-	  stop("predicted probabilities cannot be computed with missing newdata")
-	}
-	offsetx <- if(is.null(object$offset$count)) rep.int(0, NROW(X)) else object$offset$count
-	offsetz <- if(is.null(object$offset$zero))  rep.int(0, NROW(Z)) else object$offset$zero
-        mu <- exp(X %*% object$coefficients$count + offsetx)[,1]
-        phi <- object$linkinv(Z %*% object$coefficients$zero + offsetz)[,1]
+  type <- match.arg(type)
+  
+  ## if no new data supplied
+  if(missing(newdata)) {
+    rval <- object$fitted.values
+    if(type != "response") {
+      if(!is.null(object$x)) {
+        X <- object$x$count
+        Z <- object$x$zero
+      } else if(!is.null(object$model)) {
+        X <- model.matrix(object$terms$count, object$model, contrasts = object$contrasts$count)
+        Z <- model.matrix(object$terms$zero,  object$model, contrasts = object$contrasts$zero)	
+      } else {
+        stop("predicted probabilities cannot be computed with missing newdata")
       }
-    } else {
-      mf <- model.frame(delete.response(object$terms$full), newdata, na.action = na.action, xlev = object$levels)
-      X <- model.matrix(delete.response(object$terms$count), mf, contrasts = object$contrasts$count)
-      Z <- model.matrix(delete.response(object$terms$zero),  mf, contrasts = object$contrasts$zero)
-      offsetx <- model_offset_2(mf, terms = object$terms$count, offset = FALSE)
-      offsetz <- model_offset_2(mf, terms = object$terms$zero,  offset = FALSE)
-      if(is.null(offsetx)) offsetx <- rep.int(0, NROW(X))
-      if(is.null(offsetz)) offsetz <- rep.int(0, NROW(Z))
-      if(!is.null(object$call$offset)) offsetx <- offsetx + eval(object$call$offset, newdata)
-
+      offsetx <- if(is.null(object$offset$count)) rep.int(0, NROW(X)) else object$offset$count
+      offsetz <- if(is.null(object$offset$zero))  rep.int(0, NROW(Z)) else object$offset$zero
       mu <- exp(X %*% object$coefficients$count + offsetx)[,1]
       phi <- object$linkinv(Z %*% object$coefficients$zero + offsetz)[,1]
-      rval <- (1-phi) * mu
     }
+  } else {
+    mf <- model.frame(delete.response(object$terms$full), newdata, na.action = na.action, xlev = object$levels)
+    X <- model.matrix(delete.response(object$terms$count), mf, contrasts = object$contrasts$count)
+    Z <- model.matrix(delete.response(object$terms$zero),  mf, contrasts = object$contrasts$zero)
+    offsetx <- model_offset_2(mf, terms = object$terms$count, offset = FALSE)
+    offsetz <- model_offset_2(mf, terms = object$terms$zero,  offset = FALSE)
+    if(is.null(offsetx)) offsetx <- rep.int(0, NROW(X))
+    if(is.null(offsetz)) offsetz <- rep.int(0, NROW(Z))
+    if(!is.null(object$call$offset)) offsetx <- offsetx + eval(object$call$offset, newdata)
     
-    ## predicted means for count/zero component
-    if(type == "count") rval <- mu
-    if(type == "zero") rval <- phi
+    mu <- exp(X %*% object$coefficients$count + offsetx)[,1]
+    phi <- object$linkinv(Z %*% object$coefficients$zero + offsetz)[,1]
+    rval <- (1-phi) * mu
+  }
+  
+  ## predicted means for count/zero component
+  if(type == "count") rval <- mu
+  if(type == "zero") rval <- phi
+  
+  ## predicted probabilities
+  if(type == "prob") {
+    if(!is.null(object$y)) y <- object$y
+    else if(!is.null(object$model)) y <- model.response(object$model)
+    else stop("predicted probabilities cannot be computed for fits with y = FALSE and model = FALSE")
     
-    ## predicted probabilities
-    if(type == "prob") {
-      if(!is.null(object$y)) y <- object$y
-        else if(!is.null(object$model)) y <- model.response(object$model)
-	else stop("predicted probabilities cannot be computed for fits with y = FALSE and model = FALSE")
-
-      yUnique <- if(is.null(at)) 0:max(y) else at
-      nUnique <- length(yUnique)
-      rval <- matrix(NA, nrow = length(rval), ncol = nUnique)
-      dimnames(rval) <- list(rownames(X), yUnique)
-      
-      switch(object$dist,
-             "poisson" = {
-    	       rval[, 1] <- phi + (1-phi) * exp(-mu)
-               for(i in 2:nUnique) rval[,i] <- (1-phi) * dpois(yUnique[i], lambda = mu)
-             },
-	     "negbin" = {
-               theta <- object$theta
-               rval[, 1] <- phi + (1-phi) * dnbinom(0, mu = mu, size = theta)
-               for(i in 2:nUnique) rval[,i] <- (1-phi) * dnbinom(yUnique[i], mu = mu, size = theta)
-             },
-	     "geometric" = {
-               rval[, 1] <- phi + (1-phi) * dnbinom(0, mu = mu, size = 1)
-               for(i in 2:nUnique) rval[,i] <- (1-phi) * dnbinom(yUnique[i], mu = mu, size = 1)
-	     })
-    }
-   
-    rval
+    yUnique <- if(is.null(at)) 0:max(y) else at
+    nUnique <- length(yUnique)
+    rval <- matrix(NA, nrow = length(rval), ncol = nUnique)
+    dimnames(rval) <- list(rownames(X), yUnique)
+    
+    switch(object$dist,
+           "poisson" = {
+             rval[, 1] <- phi + (1-phi) * exp(-mu)
+             for(i in 2:nUnique) rval[,i] <- (1-phi) * dpois(yUnique[i], lambda = mu)
+           },
+           "negbin" = {
+             theta <- object$theta
+             rval[, 1] <- phi + (1-phi) * dnbinom(0, mu = mu, size = theta)
+             for(i in 2:nUnique) rval[,i] <- (1-phi) * dnbinom(yUnique[i], mu = mu, size = theta)
+           },
+           "geometric" = {
+             rval[, 1] <- phi + (1-phi) * dnbinom(0, mu = mu, size = 1)
+             for(i in 2:nUnique) rval[,i] <- (1-phi) * dnbinom(yUnique[i], mu = mu, size = 1)
+           })
+  }
+  
+  rval
 }
 
 fitted.zeroinfl <- function(object, ...) {
@@ -680,26 +679,26 @@ fitted.zeroinfl <- function(object, ...) {
 }
 
 residuals.zeroinfl <- function(object, type = c("pearson", "response"), ...) {
-
+  
   type <- match.arg(type)
   res <- object$residuals
-
+  
   switch(type,
-  
-  "response" = {
-    return(res)
-  },
-  
-  "pearson" = {
-    mu <- predict(object, type = "count")
-    phi <- predict(object, type = "zero")
-    theta1 <- switch(object$dist,
-      "poisson" = 0,
-      "geometric" = 1,
-      "negbin" = 1/object$theta)
-    vv <- object$fitted.values * (1 + (phi + theta1) * mu)
-    return(res/sqrt(vv))  
-  })
+         
+         "response" = {
+           return(res)
+         },
+         
+         "pearson" = {
+           mu <- predict(object, type = "count")
+           phi <- predict(object, type = "zero")
+           theta1 <- switch(object$dist,
+                            "poisson" = 0,
+                            "geometric" = 1,
+                            "negbin" = 1/object$theta)
+           vv <- object$fitted.values * (1 + (phi + theta1) * mu)
+           return(res/sqrt(vv))  
+         })
 }
 
 terms.zeroinfl <- function(x, model = c("count", "zero"), ...) {
@@ -709,13 +708,13 @@ terms.zeroinfl <- function(x, model = c("count", "zero"), ...) {
 model.matrix.zeroinfl <- function(object, model = c("count", "zero"), ...) {
   model <- match.arg(model)
   if(!is.null(object$x)) rval <- object$x[[model]]
-    else if(!is.null(object$model)) rval <- model.matrix(object$terms[[model]], object$model, contrasts = object$contrasts[[model]])
-    else stop("not enough information in fitted model to return model.matrix")
+  else if(!is.null(object$model)) rval <- model.matrix(object$terms[[model]], object$model, contrasts = object$contrasts[[model]])
+  else stop("not enough information in fitted model to return model.matrix")
   return(rval)
 }
 
 predprob.zeroinfl <- function(obj, ...) {
-    predict(obj, type = "prob", ...)
+  predict(obj, type = "prob", ...)
 }
 
 extractAIC.zeroinfl <- function(fit, scale = NULL, k = 2, ...) {

--- a/R/zeroinfl.R
+++ b/R/zeroinfl.R
@@ -318,7 +318,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
     }
     
     ## EM estimation of starting values
-    if(ocontrol$EM & dist == "poisson" & fit$converge == 0) {
+    if(ocontrol$EM & dist == "poisson" & fit$convergence == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dpois(0, mui))
@@ -342,7 +342,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
       }
     }
     
-    if(ocontrol$EM & dist == "geometric" & fit$converge == 0) {
+    if(ocontrol$EM & dist == "geometric" & fit$convergence == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dnbinom(0, size = 1, mu = mui))
@@ -370,7 +370,7 @@ zeroinfl <- function(formula, data, subset, na.action, weights, offset,
       }
     }
     
-    if(ocontrol$EM & dist == "negbin" & fit$converge == 0) {
+    if(ocontrol$EM & dist == "negbin" & fit$convergence == 0) {
       mui <- model_count$fitted
       probi <- model_zero$fitted
       probi <- probi/(probi + (1-probi) * dnbinom(0, size = start$theta, mu = mui))


### PR DESCRIPTION
This PR solves two bugs in `pscl`. 

(1) 
In hurdle.R and zeroinfl.R, some matrices have not specified the `drop = FALSE` argument. As documented in an open GitHub issue (https://github.com/atahk/pscl/issues/16), an error occurs when we have 1x1 matrix. Because we do not specify the `drop = FALSE` argument, R returns a numeric value. This later messes up the downstream matrix calculations in the function.  Adding `drop = FALSE` solves any downstream issues. 

(2)
Secondly, another error (https://github.com/atahk/pscl/issues/11) was noted in the GitHub repo whereby when users set the control to an EM algo within a zero-inflated count model, they received the following error: `object 'model_count' not found`. This error occurs because the model_count object was defined within an if statement in L310 of zeroinfl.R, where the convergence of the `stats::optim()` function must be greater than 0. But docs for `stats::optim` note that 0 means the result converged and a result greater than 0 corresponds to a particular warning. So it seems like this is a coding error:

**L.310 in zeroinfl.R:** 
```
if(fit$convergence > 0)
```
(fit was the assigned name of the optim function).

We would ideally expect the results of optim$convergence to be 0 because, as noted above, this means that the result converged. So L310 has been changed to `if(fit$convergence == 0))`.

Then the following if() statements can be changed to also specify that the fit$converge must also equal zero: 
```
if(ocontrol$EM & dist == "poisson")
if(ocontrol$EM & dist == "geometric")
if(ocontrol$EM & dist == "negbin")
```
should become 
```
if(ocontrol$EM & dist == "poisson" & fit$convergence == 0)
if(ocontrol$EM & dist == "geometric" & fit$convergence == 0)
if(ocontrol$EM & dist == "negbin" & fit$convergence == 0)
```
Because `if(fit$convergence > 0)` becomes `if(fit$convergence == 0)`, zero-inflated model with an EM algorithm now work as expected.

It also seems like the general convergence issue is addressed further on in the function with this warning: 
```
if(fit$convergence > 0) warning("optimization failed to converge")
```

So long as `fit$convergence == 0`, the model_count object should exist. If not, the warning will return.  When running the following example, the proposed changes work as expected: `fm2 <- zeroinfl(art ~ ., data = bioChemists, EM = TRUE)`. 

In summary:
* Add drop = FALSE to some matrices in the zeroinfl and hurdle functions.
* Specify that the optim convergence must equal 0 (which means the model converged) in the zeroinfl function. 
